### PR TITLE
Ensure pct_test() is only run in FIPS mode.

### DIFF
--- a/lib/nettle/pk.c
+++ b/lib/nettle/pk.c
@@ -3441,10 +3441,12 @@ wrap_nettle_pk_generate_keys(gnutls_pk_algorithm_t algo,
 	params->algo = algo;
 
 #ifdef ENABLE_FIPS140
-	ret = pct_test(algo, params);
-	if (ret < 0) {
-		gnutls_assert();
-		goto cleanup;
+	if (_gnutls_fips_mode_enabled()) {
+		ret = pct_test(algo, params);
+		if (ret < 0) {
+			gnutls_assert();
+			goto cleanup;
+		}
 	}
 #endif
 


### PR DESCRIPTION
Ensure pct_test() is only run in FIPS mode.

https://build.opensuse.org/projects/SUSE:SLE-15-SP6:Update/packages/gnutls/files/gnutls-pct-in-FIPS-only.patch?expand=1